### PR TITLE
Update bevy_egui to 0.35

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,12 +115,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aligned-vec"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aa90d7ce82d4be67b64039a3d588d38dbcc6736577de4a847025ce5b0c468d1"
-
-[[package]]
 name = "alsa"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,12 +206,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arbitrary"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
-
-[[package]]
 name = "arboard"
 version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,17 +221,6 @@ dependencies = [
  "parking_lot",
  "windows-sys 0.48.0",
  "x11rb",
-]
-
-[[package]]
-name = "arg_enum_proc_macro"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -396,29 +373,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "av1-grain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6678909d8c5d46a42abcf571271e15fdbc0a225e3646cf23762cd415046c78bf"
-dependencies = [
- "anyhow",
- "arrayvec",
- "log",
- "nom",
- "num-rational",
- "v_frame",
-]
-
-[[package]]
-name = "avif-serialize"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98922d6a4cfbcb08820c69d8eeccc05bb1f29bfa06b4f5b1dbfe9a868bd7608e"
-dependencies = [
- "arrayvec",
-]
-
-[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,9 +512,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_app"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b6267ac23a9947d5b2725ff047a1e1add70076d85fa9fb73d044ab9bea1f3c"
+checksum = "4491cc4c718ae76b4c6883df58b94cc88b32dcd894ea8d5b603c7c7da72ca967"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -581,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_asset"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0698040d63199391ea77fd02e039630748e3e335c3070c6d932fd96cbf80f5d6"
+checksum = "f56111d9b88d8649f331a667d9d72163fb26bd09518ca16476d238653823db1e"
 dependencies = [
  "async-broadcast",
  "async-fs",
@@ -621,9 +575,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_asset_macros"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf8c00b5d532f8e5ac7b49af10602f9f7774a2d522cf0638323b5dfeee7b31c"
+checksum = "a4cca3e67c0ec760d8889d42293d987ce5da92eaf9c592bf5d503728a63b276d"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -651,9 +605,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_color"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddf6a5ad35496bbc41713efbcf06ab72b9a310fabcab0f9db1debb56e8488c6e"
+checksum = "5c101cbe1e26b8d701eb77263b14346e2e0cbbd2a6e254b9b1aead814e5ca8d3"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -667,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_core_pipeline"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55c2310717b9794e4a45513ee5946a7be0838852a4c1e185884195e1a8688ff3"
+checksum = "59ed46363cad80dc00f08254c3015232bd6f640738403961c6d63e7ecfc61625"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -697,9 +651,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_derive"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f626531b9c05c25a758ede228727bd11c2c2c8498ecbed9925044386d525a2a3"
+checksum = "1b837bf6c51806b10ebfa9edf1844ad80a3a0760d6c5fac4e90761df91a8901a"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -708,9 +662,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_diagnostic"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "048a1ff3944a534b8472516866284181eef0a75b6dd4d39b6e5925715e350766"
+checksum = "48797366f312a8f31e237d08ce3ee70162591282d2bfe7c5ad8be196fb263e55"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -726,9 +680,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9e807b5d9aab3bb8dfe47e7a44c9ff088bad2ceefe299b80ac77609a87fe9d4"
+checksum = "3c2bf6521aae57a0ec3487c4bfb59e36c4a378e834b626a4bea6a885af2fdfe7"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -754,9 +708,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs_macros"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467d7bb98aeb8dd30f36e6a773000c12a891d4f1bee2adc3841ec89cc8eaf54e"
+checksum = "38748d6f3339175c582d751f410fb60a93baf2286c3deb7efebb0878dce7f413"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -766,13 +720,14 @@ dependencies = [
 
 [[package]]
 name = "bevy_egui"
-version = "0.34.1"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3d58a8afdb6100bca50251043a85320391742cae125d559f6cca3a16b84cdd"
+checksum = "dd67c9ddb60d10926899c3eaa022aee43fb92ba507191c62e1ff935b323c5a98"
 dependencies = [
  "arboard",
  "bevy_app",
  "bevy_asset",
+ "bevy_core_pipeline",
  "bevy_derive",
  "bevy_ecs",
  "bevy_image",
@@ -784,6 +739,7 @@ dependencies = [
  "bevy_reflect",
  "bevy_render",
  "bevy_time",
+ "bevy_transform",
  "bevy_window",
  "bevy_winit",
  "bytemuck",
@@ -803,9 +759,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_encase_derive"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8bb31dc1090c6f8fabbf6b21994d19a12766e786885ee48ffc547f0f1fa7863"
+checksum = "8148f4edee470a2ea5cad010184c492a4c94c36d7a7158ea28e134ea87f274ab"
 dependencies = [
  "bevy_macro_utils",
  "encase_derive_impl",
@@ -902,9 +858,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_image"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "840b25f7f58894c641739f756959028a04f519c448db7e2cd3e2e29fc5fd188d"
+checksum = "65e6e900cfecadbc3149953169e36b9e26f922ed8b002d62339d8a9dc6129328"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -930,9 +886,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_input"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "763410715714f3d4d2dcdf077af276e2e4ea93fd8081b183d446d060ea95baaa"
+checksum = "18d6b6516433f6f7d680f648d04eb1866bb3927a1782d52f74831b62042f3cd1"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1007,9 +963,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_log"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7156df8d2f11135cf71c03eb4c11132b65201fd4f51648571e59e39c9c9ee2f6"
+checksum = "d7a61ee8aef17a974f5ca481dcedf0c2bd52670e231d4c4bc9ddef58328865f9"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -1024,9 +980,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_macro_utils"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2473db70d8785b5c75d6dd951a2e51e9be2c2311122db9692c79c9d887517b"
+checksum = "052eeebcb8e7e072beea5031b227d9a290f8a7fbbb947573ab6ec81df0fb94be"
 dependencies = [
  "parking_lot",
  "proc-macro2",
@@ -1037,9 +993,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_math"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a3a926d02dc501c6156a047510bdb538dcb1fa744eeba13c824b73ba88de55"
+checksum = "68553e0090fe9c3ba066c65629f636bd58e4ebd9444fdba097b91af6cd3e243f"
 dependencies = [
  "approx",
  "bevy_reflect",
@@ -1057,9 +1013,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_mesh"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12af58280c7453e32e2f083d86eaa4c9b9d03ea8683977108ded8f1930c539f2"
+checksum = "b10399c7027001edbc0406d7d0198596b1f07206c1aae715274106ba5bdcac40"
 dependencies = [
  "bevy_asset",
  "bevy_derive",
@@ -1082,9 +1038,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_mikktspace"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75e0258423c689f764556e36b5d9eebdbf624b29a1fd5b33cd9f6c42dcc4d5f3"
+checksum = "8bb60c753b968a2de0fd279b76a3d19517695e771edb4c23575c7f92156315de"
 dependencies = [
  "glam",
 ]
@@ -1150,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_platform"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704db2c11b7bc31093df4fbbdd3769f9606a6a5287149f4b51f2680f25834ebc"
+checksum = "f7573dc824a1b08b4c93fdbe421c53e1e8188e9ca1dd74a414455fe571facb47"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -1168,15 +1124,15 @@ dependencies = [
 
 [[package]]
 name = "bevy_ptr"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f1275dfb4cfef4ffc90c3fa75408964864facf833acc932413d52aa5364ba4"
+checksum = "df7370d0e46b60e071917711d0860721f5347bc958bf325975ae6913a5dfcf01"
 
 [[package]]
 name = "bevy_reflect"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "607ebacc31029cf2f39ac330eabf1d4bc411b159528ec08dbe6b0593eaccfd41"
+checksum = "daeb91a63a1a4df00aa58da8cc4ddbd4b9f16ab8bb647c5553eb156ce36fa8c2"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -1201,9 +1157,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_reflect_derive"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf35e45e4eb239018369f63f2adc2107a54c329f9276d020e01eee1625b0238b"
+checksum = "40ddadc55fe16b45faaa54ab2f9cb00548013c74812e8b018aa172387103cce6"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -1214,9 +1170,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_render"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a7306235b3343b032801504f3e884b93abfb7ba58179fc555c479df509f349"
+checksum = "ef91fed1f09405769214b99ebe4390d69c1af5cdd27967deae9135c550eb1667"
 dependencies = [
  "async-channel",
  "bevy_app",
@@ -1266,9 +1222,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_render_macros"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b85c4fb26b66d3a257b655485d11b9b6df9d3c85026493ba8092767a5edfc1b2"
+checksum = "abd42cf6c875bcf38da859f8e731e119a6aff190d41dd0a1b6000ad57cf2ed3d"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -1357,9 +1313,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_tasks"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444c450b65e108855f42ecb6db0c041a56ea7d7f10cc6222f0ca95e9536a7d19"
+checksum = "5b674242641cab680688fc3b850243b351c1af49d4f3417a576debd6cca8dcf5"
 dependencies = [
  "async-channel",
  "async-executor",
@@ -1409,9 +1365,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_time"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456369ca10f8e039aaf273332744674844827854833ee29e28f9e161702f2f55"
+checksum = "bc98eb356c75be04fbbc77bb3d8ffa24c8bacd99f76111cee23d444be6ac8c9c"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1424,9 +1380,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_transform"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8479cdd5461246943956a7c8347e4e5d6ff857e57add889fb50eee0b5c26ab48"
+checksum = "df218e440bb9a19058e1b80a68a031c887bcf7bd3a145b55f361359a2fa3100d"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1477,9 +1433,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_utils"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac2da3b3c1f94dadefcbe837aaa4aa119fcea37f7bdc5307eb05b4ede1921e24"
+checksum = "94f7a8905a125d2017e8561beefb7f2f5e67e93ff6324f072ad87c5fd6ec3b99"
 dependencies = [
  "bevy_platform",
  "thread_local",
@@ -1487,9 +1443,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_window"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d83327cc5584da463d12b7a88ddb97f9e006828832287e1564531171fffdeb4"
+checksum = "df7e8ad0c17c3cc23ff5566ae2905c255e6986037fb041f74c446216f5c38431"
 dependencies = [
  "android-activity",
  "bevy_app",
@@ -1591,12 +1547,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
-name = "bit_field"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1610,12 +1560,6 @@ checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "bitstream-io"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6099cdc01846bc367c4e7dd630dc5966dccf36b652fae7a74e17b640411a91b2"
 
 [[package]]
 name = "blake3"
@@ -1691,12 +1635,6 @@ dependencies = [
  "bevy",
  "my_library_flappy_collision",
 ]
-
-[[package]]
-name = "built"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ed6191a7e78c36abdb16ab65341eefd73d64d303fffccdbb00d51e4205967b"
 
 [[package]]
 name = "bumpalo"
@@ -1798,16 +1736,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
  "nom",
-]
-
-[[package]]
-name = "cfg-expr"
-version = "0.15.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
-dependencies = [
- "smallvec",
- "target-lexicon",
 ]
 
 [[package]]
@@ -1914,12 +1842,6 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
-
-[[package]]
-name = "color_quant"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "combine"
@@ -2526,21 +2448,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "exr"
-version = "1.73.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83197f59927b46c04a183a619b7c29df34e63e63c7869320862268c0ef687e0"
-dependencies = [
- "bit_field",
- "half 2.4.1",
- "lebe",
- "miniz_oxide",
- "rayon-core",
- "smallvec",
- "zune-inflate",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2816,16 +2723,6 @@ dependencies = [
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
-]
-
-[[package]]
-name = "gif"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb2d69b19215e18bb912fa30f7ce15846e301408695e44e0ef719f1da9e19f2"
-dependencies = [
- "color_quant",
- "weezl",
 ]
 
 [[package]]
@@ -3357,36 +3254,10 @@ checksum = "cd6f44aed642f18953a158afeb30206f4d50da59fbc66ecb53c66488de73563b"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
- "color_quant",
- "exr",
- "gif",
- "image-webp",
  "num-traits",
  "png",
- "qoi",
- "ravif",
- "rayon",
- "rgb",
  "tiff",
- "zune-core",
- "zune-jpeg",
 ]
-
-[[package]]
-name = "image-webp"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b77d01e822461baa8409e156015a1d91735549f0f2c17691bd2d996bef238f7f"
-dependencies = [
- "byteorder-lite",
- "quick-error",
-]
-
-[[package]]
-name = "imgref"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0263a3d970d5c054ed9312c0057b4f3bde9c0b33836d3637361d4a9e6e7a408"
 
 [[package]]
 name = "immutable-chunkmap"
@@ -3435,17 +3306,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "interpolate_name"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "io-kit-sys"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3471,15 +3331,6 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -3588,12 +3439,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lebe"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
-
-[[package]]
 name = "lewton"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3609,16 +3454,6 @@ name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
-
-[[package]]
-name = "libfuzzer-sys"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf78f52d400cf2d84a3a973a78a592b4adc535739e0a5597a0da6f0c357adc75"
-dependencies = [
- "arbitrary",
- "cc",
-]
 
 [[package]]
 name = "libloading"
@@ -3690,15 +3525,6 @@ name = "log"
 version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
-
-[[package]]
-name = "loop9"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
-dependencies = [
- "imgref",
-]
 
 [[package]]
 name = "mach2"
@@ -3798,16 +3624,6 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
-name = "maybe-rayon"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
-dependencies = [
- "cfg-if",
- "rayon",
-]
 
 [[package]]
 name = "memchr"
@@ -4185,12 +4001,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4225,12 +4035,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
 
 [[package]]
-name = "noop_proc_macro"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
-
-[[package]]
 name = "ntapi"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4250,16 +4054,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4268,26 +4062,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
 ]
 
 [[package]]
@@ -4913,34 +4687,6 @@ name = "profiling"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afbdc74edc00b6f6a218ca6a5364d6226a259d4b8ea1af4a0ea063f27e179f4d"
-dependencies = [
- "profiling-procmacros",
-]
-
-[[package]]
-name = "profiling-procmacros"
-version = "1.0.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a65f2e60fbf1063868558d69c6beacf412dc755f9fc020f514b7955fc914fe30"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
-name = "qoi"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
-name = "quick-error"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -5041,56 +4787,6 @@ name = "rangemap"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60fcc7d6849342eff22c4350c8b9a989ee8ceabc4b481253e8946b9fe83d684"
-
-[[package]]
-name = "rav1e"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd87ce80a7665b1cce111f8a16c1f3929f6547ce91ade6addf4ec86a8dda5ce9"
-dependencies = [
- "arbitrary",
- "arg_enum_proc_macro",
- "arrayvec",
- "av1-grain",
- "bitstream-io",
- "built",
- "cfg-if",
- "interpolate_name",
- "itertools 0.12.1",
- "libc",
- "libfuzzer-sys",
- "log",
- "maybe-rayon",
- "new_debug_unreachable",
- "noop_proc_macro",
- "num-derive",
- "num-traits",
- "once_cell",
- "paste",
- "profiling",
- "rand",
- "rand_chacha",
- "simd_helpers",
- "system-deps",
- "thiserror 1.0.69",
- "v_frame",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "ravif"
-version = "0.11.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6a5f31fcf7500f9401fea858ea4ab5525c99f2322cfcee732c0e6c74208c0c6"
-dependencies = [
- "avif-serialize",
- "imgref",
- "loop9",
- "quick-error",
- "rav1e",
- "rayon",
- "rgb",
-]
 
 [[package]]
 name = "raw-window-handle"
@@ -5201,12 +4897,6 @@ name = "renderdoc-sys"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
-
-[[package]]
-name = "rgb"
-version = "0.8.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
 
 [[package]]
 name = "ring"
@@ -5444,15 +5134,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5493,15 +5174,6 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
-
-[[package]]
-name = "simd_helpers"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
-dependencies = [
- "quote",
-]
 
 [[package]]
 name = "skrifa"
@@ -5719,19 +5391,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-deps"
-version = "6.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
-dependencies = [
- "cfg-expr",
- "heck",
- "pkg-config",
- "toml",
- "version-compare",
-]
-
-[[package]]
 name = "taffy"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5742,12 +5401,6 @@ dependencies = [
  "serde",
  "slotmap",
 ]
-
-[[package]]
-name = "target-lexicon"
-version = "0.12.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "termcolor"
@@ -5918,25 +5571,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.8.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
 name = "toml_datetime"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "toml_edit"
@@ -5945,8 +5583,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
  "indexmap",
- "serde",
- "serde_spanned",
  "toml_datetime",
  "winnow",
 ]
@@ -6217,17 +5853,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "v_frame"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f32aaa24bacd11e488aa9ba66369c7cd514885742c9fe08cfe85884db3e92b"
-dependencies = [
- "aligned-vec",
- "num-traits",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6249,12 +5874,6 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
-name = "version-compare"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
 
 [[package]]
 name = "version_check"
@@ -7394,28 +7013,4 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "zune-core"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
-
-[[package]]
-name = "zune-inflate"
-version = "0.2.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
-dependencies = [
- "simd-adler32",
-]
-
-[[package]]
-name = "zune-jpeg"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99a5bab8d7dedf81405c4bb1f2b83ea057643d9cb28778cea9eecddeedd2e028"
-dependencies = [
- "zune-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ members = [
 
 [workspace.dependencies]
 bevy = "0.16.0"
-bevy_egui = "0.34.1"
+bevy_egui = "0.35.0"
 anyhow = "1"
 rand = "0.8"
 rand_pcg = { version = "0.3" }

--- a/FirstLibraryCreate/pig/src/main.rs
+++ b/FirstLibraryCreate/pig/src/main.rs
@@ -1,6 +1,6 @@
 //START: main
 use bevy::prelude::*;
-use bevy_egui::{egui, EguiContexts, EguiPlugin}; //<callout id="first_library_create.pig.egui" />
+use bevy_egui::{egui, EguiContexts, EguiPlugin, EguiPrimaryContextPass}; //<callout id="first_library_create.pig.egui" />
 use my_library::RandomNumberGenerator; //<callout id="first_library_create.pig.use" />
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, Default, States)] //<callout id="first_library_create.pig.state" />
@@ -13,11 +13,11 @@ enum GamePhase {
 fn main() {
   App::new()
     .add_plugins(DefaultPlugins)
-    .add_plugins(EguiPlugin{ enable_multipass_for_primary_context: false })
+    .add_plugins(EguiPlugin::default())
     .add_systems(Startup, setup) //<callout id="first_library_create.pig.call_setup" />
     .init_state::<GamePhase>() //<callout id="first_library_create.pig.setup_state" />
-    .add_systems(Update, display_score) //<callout id="first_library_create.pig.call_score" />
-    .add_systems(Update, player.run_if(
+    .add_systems(EguiPrimaryContextPass, display_score) //<callout id="first_library_create.pig.call_score" />
+    .add_systems(EguiPrimaryContextPass, player.run_if(
       in_state(GamePhase::Player))) //<callout id="first_library_create.pig.call_player_update" />
     .add_systems(Update, cpu.run_if(
       in_state(GamePhase::Cpu))) //<callout id="first_library_create.pig.call_cpu_update" />
@@ -74,11 +74,12 @@ fn setup(
 fn display_score(
   scores: Res<Scores>,
   mut egui_context: EguiContexts, //<callout id="first_library_create.pig.egui_ctx" />
-) {
-  egui::Window::new("Total Scores").show(egui_context.ctx_mut(), |ui| {//<callout id="first_library_create.pig.egui_window" />
+) -> Result {
+  egui::Window::new("Total Scores").show(egui_context.ctx_mut()?, |ui| {//<callout id="first_library_create.pig.egui_window" />
     ui.label(&format!("Player: {}", scores.player)); //<callout id="first_library_create.pig.show_player_score" />
     ui.label(&format!("CPU: {}", scores.cpu));
   });
+  Ok(())
 }
 //END: display_score
 
@@ -130,8 +131,8 @@ fn player(
   mut scores: ResMut<Scores>,
   mut state: ResMut<NextState<GamePhase>>,//<callout id="first_library_create.pig.next_state" />
   mut egui_context: EguiContexts,
-) {
-  egui::Window::new("Play Options").show(egui_context.ctx_mut(), |ui| {
+) -> Result {
+  egui::Window::new("Play Options").show(egui_context.ctx_mut()?, |ui| {
     let hand_score: usize =
       hand_query.iter().map(|(_, ts)| ts.texture_atlas
       .as_ref().unwrap().index + 1).sum();//<callout id="first_library_create.pig.hand_score" />
@@ -162,6 +163,7 @@ fn player(
       state.set(GamePhase::Cpu);
     }
   });
+  Ok(())
 }
 //END: player
 

--- a/FirstLibraryGenericRange/pig/src/main.rs
+++ b/FirstLibraryGenericRange/pig/src/main.rs
@@ -1,6 +1,6 @@
 //START: main
 use bevy::prelude::*;
-use bevy_egui::{egui, EguiContexts, EguiPlugin};
+use bevy_egui::{egui, EguiContexts, EguiPlugin, EguiPrimaryContextPass};
 use my_library::RandomNumberGenerator; //<callout id="first_library_create.pig.use" /> //<callout id="first_library_create.pig.egui" />
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, States, Default)] //<callout id="first_library_create.pig.state" />
@@ -13,11 +13,11 @@ enum GamePhase {
 fn main() {
   App::new()
   .add_plugins(DefaultPlugins)
-  .add_plugins(EguiPlugin{ enable_multipass_for_primary_context: false })
+  .add_plugins(EguiPlugin::default())
   .add_systems(Startup, setup) //<callout id="first_library_create.pig.call_setup" />
   .init_state::<GamePhase>() //<callout id="first_library_create.pig.setup_state" />
-  .add_systems(Update, display_score) //<callout id="first_library_create.pig.call_score" />
-  .add_systems(Update, player.run_if(
+  .add_systems(EguiPrimaryContextPass, display_score) //<callout id="first_library_create.pig.call_score" />
+  .add_systems(EguiPrimaryContextPass, player.run_if(
     in_state(GamePhase::Player))) //<callout id="first_library_create.pig.call_player_update" />
   .add_systems(Update, cpu.run_if(
     in_state(GamePhase::Cpu))) //<callout id="first_library_create.pig.call_cpu_update" />
@@ -74,12 +74,13 @@ fn setup(
 fn display_score(
   scores: Res<Scores>,
   mut egui_context: EguiContexts, //<callout id="first_library_create.pig.egui_ctx" />
-) {
-  egui::Window::new("Total Scores").show(egui_context.ctx_mut(), |ui| {
+) -> Result {
+  egui::Window::new("Total Scores").show(egui_context.ctx_mut()?, |ui| {
     //<callout id="first_library_create.pig.egui_window" />
     ui.label(&format!("Player: {}", scores.player)); //<callout id="first_library_create.pig.show_player_score" />
     ui.label(&format!("CPU: {}", scores.cpu));
   });
+  Ok(())
 }
 //END: display_score
 
@@ -130,8 +131,8 @@ fn player(
   mut scores: ResMut<Scores>,
   mut state: ResMut<NextState<GamePhase>>,
   mut egui_context: EguiContexts,
-) {
-  egui::Window::new("Play Options").show(egui_context.ctx_mut(), |ui| {
+) -> Result {
+  egui::Window::new("Play Options").show(egui_context.ctx_mut()?, |ui| {
     let hand_score: usize =
       hand_query.iter().map(|(_, ts)| 
       ts.texture_atlas.as_ref().unwrap().index + 1).sum();//<callout id="first_library_create.pig.hand_score" />
@@ -161,6 +162,7 @@ fn player(
       state.set(GamePhase::Cpu);
     }
   });
+  Ok(())
 }
 //END: player
 

--- a/FirstLibraryMutableRandomPlugin/pig/src/main.rs
+++ b/FirstLibraryMutableRandomPlugin/pig/src/main.rs
@@ -13,7 +13,7 @@ enum GamePhase {
 fn main() {
   App::new()
     .add_plugins(DefaultPlugins)
-    .add_plugins(EguiPlugin{ enable_multipass_for_primary_context: false })
+    .add_plugins(EguiPlugin::default())
     .add_plugins(RandomPlugin)//<callout id="random.bevy.add_plugin" />
     .add_systems(Startup, setup) 
     .init_state::<GamePhase>() 
@@ -70,12 +70,13 @@ fn setup(
 fn display_score(
   scores: Res<Scores>,
   mut egui_context: EguiContexts, //<callout id="first_library_create.pig.egui_ctx" />
-) {
-  egui::Window::new("Total Scores").show(egui_context.ctx_mut(), |ui| {
+) -> Result {
+  egui::Window::new("Total Scores").show(egui_context.ctx_mut()?, |ui| {
     //<callout id="first_library_create.pig.egui_window" />
     ui.label(&format!("Player: {}", scores.player)); //<callout id="first_library_create.pig.show_player_score" />
     ui.label(&format!("CPU: {}", scores.cpu));
   });
+  Ok(())
 }
 //END: display_score
 
@@ -126,8 +127,8 @@ fn player(
   mut scores: ResMut<Scores>,
   mut state: ResMut<NextState<GamePhase>>,
   mut egui_context: EguiContexts,
-) {
-  egui::Window::new("Play Options").show(egui_context.ctx_mut(), |ui| {
+) -> Result {
+  egui::Window::new("Play Options").show(egui_context.ctx_mut()?, |ui| {
     let hand_score: usize =
       hand_query.iter().map(|(_, ts)| ts.texture_atlas.as_ref().unwrap().index + 1).sum();//<callout id="first_library_create.pig.hand_score" />
     ui.label(&format!("Score for this hand: {hand_score}"));
@@ -156,6 +157,7 @@ fn player(
       state.set(GamePhase::Cpu);
     }
   });
+  Ok(())
 }
 //END: player
 

--- a/FlappyAnimation/my_library/src/bevy_assets/loading_menu.rs
+++ b/FlappyAnimation/my_library/src/bevy_assets/loading_menu.rs
@@ -40,7 +40,7 @@ pub(crate) fn run<T>(
     mut texture_atlases: ResMut<Assets<TextureAtlasLayout>>,
     loaded_assets: Res<LoadedAssets>,
     // END_HIGHLIGHT
-) where T: States+FromWorld+FreelyMutableState,
+) -> Result where T: States+FromWorld+FreelyMutableState,
 {
     to_load.0.retain(|handle| {
         match asset_server.get_load_state(handle.id()) {
@@ -57,11 +57,12 @@ pub(crate) fn run<T>(
     }
     //END: finished_loading
     Window::new("Loading, Please Wait").show(
-        egui_context.ctx_mut(), |ui| {
+        egui_context.ctx_mut()?, |ui| {
             ui.label(
                 format!("{} assets remaining", to_load.0.len())
             )
       });
+    Ok(())
 }
 
 //START: load_atlases

--- a/FlappyAnimation/my_library/src/bevy_framework/mod.rs
+++ b/FlappyAnimation/my_library/src/bevy_framework/mod.rs
@@ -2,6 +2,7 @@ mod bevy_animation;
 pub use bevy_animation::*;
 use bevy::prelude::*;
 use bevy::state::state::FreelyMutableState;
+use bevy_egui::EguiPrimaryContextPass;
 
 mod game_menus;
 
@@ -30,7 +31,7 @@ where
   fn build(&self, app: &mut App) {
     app.init_state::<T>();    
     //START_HIGHLIGHT
-    app.add_plugins(bevy_egui::EguiPlugin{ enable_multipass_for_primary_context: false });
+    app.add_plugins(bevy_egui::EguiPlugin::default());
     //END_HIGHLIGHT
     let start = MenuResource {
       menu_state: self.menu_state,
@@ -49,7 +50,7 @@ where
     app.add_systems(OnExit(self.game_end_state), cleanup::<game_menus::MenuElement>);
 
     app.add_systems(OnEnter(T::default()), crate::bevy_assets::setup);
-    app.add_systems(Update, crate::bevy_assets::run::<T>.run_if(in_state(T::default())));
+    app.add_systems(EguiPrimaryContextPass, crate::bevy_assets::run::<T>.run_if(in_state(T::default())));
     app.add_systems(OnExit(T::default()), crate::bevy_assets::exit);
   }
 }

--- a/FlappyAssetsLoadingMenu/my_library/src/bevy_assets/loading_menu.rs
+++ b/FlappyAssetsLoadingMenu/my_library/src/bevy_assets/loading_menu.rs
@@ -36,7 +36,7 @@ pub(crate) fn run<T>(
     mut state: ResMut<NextState<T>>,
     mut egui_context: EguiContexts,
     menu_info: Res<MenuResource<T>>,
-) where T: States+FromWorld+FreelyMutableState,
+) -> Result where T: States+FromWorld+FreelyMutableState,
 {
     to_load.0.retain(|handle| {//<callout id="loading_menu.retain" />
         match asset_server.get_load_state(handle.id()) {//<callout id="loading_menu.get_load_state" />
@@ -48,11 +48,12 @@ pub(crate) fn run<T>(
         state.set(menu_info.menu_state.clone());
     }
     Window::new("Loading, Please Wait").show(//<callout id="loading_menu.inform" />
-        egui_context.ctx_mut(), |ui| {
+        egui_context.ctx_mut()?, |ui| {
             ui.label(
                 format!("{} assets remaining", to_load.0.len())
             )
       });
+    Ok(())
 }
 //END: run
 

--- a/FlappyAssetsLoadingMenu/my_library/src/bevy_framework/mod.rs
+++ b/FlappyAssetsLoadingMenu/my_library/src/bevy_framework/mod.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 use bevy::state::state::FreelyMutableState;
+use bevy_egui::EguiPrimaryContextPass;
 
 mod game_menus;
 
@@ -28,7 +29,7 @@ where
   fn build(&self, app: &mut App) {
     app.init_state::<T>();    
     //START_HIGHLIGHT
-    app.add_plugins(bevy_egui::EguiPlugin{ enable_multipass_for_primary_context: false });
+    app.add_plugins(bevy_egui::EguiPlugin::default());
     //END_HIGHLIGHT
     let start = MenuResource {
       menu_state: self.menu_state,
@@ -51,7 +52,7 @@ where
       cleanup::<game_menus::MenuElement>);
 
     app.add_systems(OnEnter(T::default()), crate::bevy_assets::setup);
-    app.add_systems(Update, crate::bevy_assets::run::<T>
+    app.add_systems(EguiPrimaryContextPass, crate::bevy_assets::run::<T>
       .run_if(in_state(T::default())));
     app.add_systems(OnExit(T::default()), crate::bevy_assets::exit);
   }

--- a/FlappyCollision/bouncy/src/main.rs
+++ b/FlappyCollision/bouncy/src/main.rs
@@ -3,6 +3,7 @@ use bevy::{
   prelude::*,
 };
 use my_library_flappy_collision::{egui::egui::Color32, *};
+use my_library_flappy_collision::egui::EguiPrimaryContextPass;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, Default, States)]
 pub enum GamePhase {
@@ -29,7 +30,7 @@ fn main() -> anyhow::Result<()> {
   let mut app = App::new();
   add_phase!(app, GamePhase, GamePhase::Bouncing,
     start => [ setup ],
-    run => [ warp_at_edge, collisions, show_performance,
+    run => [ warp_at_edge, collisions,
       continual_parallax, physics_clock, sum_impulses, apply_velocity ],
     exit => [ cleanup::<BouncyElement> ]
   );
@@ -57,6 +58,7 @@ fn main() -> anyhow::Result<()> {
     .add_plugins(
       AssetManager::new().add_image("green_ball", "green_ball.png")?,
     )
+    .add_systems(EguiPrimaryContextPass, show_performance.run_if(in_state(GamePhase::Bouncing)))
     .run();
 
   Ok(())
@@ -129,7 +131,7 @@ fn show_performance(
   assets: Res<AssetStore>,
   query: Query<&Transform, With<Ball>>,
   loaded_assets: Res<LoadedAssets>,
-) {
+) -> Result {
   let n_balls = query.iter().count();//<callout id="bouncy.count_balls" />
   let fps = diagnostics//<callout id="bouncy.get_fps" />
     .get(&FrameTimeDiagnosticsPlugin::FPS)
@@ -137,7 +139,7 @@ fn show_performance(
     .unwrap();
   collision_time.fps = fps;
   egui::egui::Window::new("Performance").show(
-    egui_context.ctx_mut(),
+    egui_context.ctx_mut()?,
     |ui| {
       let fps_text = format!("FPS: {fps:.1}");//<callout id="bouncy.format_ball_count" />
       let color = match fps as u32 {//<callout id="bouncy.colorize" />
@@ -178,6 +180,7 @@ fn show_performance(
       }
     },
   );
+  Ok(())
 }
 //END: show_performance
 

--- a/FlappyCollision/my_library/src/bevy_assets/loading_menu.rs
+++ b/FlappyCollision/my_library/src/bevy_assets/loading_menu.rs
@@ -40,7 +40,7 @@ pub(crate) fn run<T>(
     mut texture_atlases: ResMut<Assets<TextureAtlasLayout>>,
     loaded_assets: Res<LoadedAssets>,
     // END_HIGHLIGHT
-) where T: States+FromWorld+FreelyMutableState,
+) -> Result where T: States+FromWorld+FreelyMutableState,
 {
     to_load.0.retain(|handle| {
         match asset_server.get_load_state(handle.id()) {
@@ -57,11 +57,12 @@ pub(crate) fn run<T>(
     }
     //END: finished_loading
     Window::new("Loading, Please Wait").show(
-        egui_context.ctx_mut(), |ui| {
+        egui_context.ctx_mut()?, |ui| {
             ui.label(
                 format!("{} assets remaining", to_load.0.len())
             )
         });
+    Ok(())
 }
 
 //START: load_atlases

--- a/FlappyCollision/my_library/src/bevy_framework/mod.rs
+++ b/FlappyCollision/my_library/src/bevy_framework/mod.rs
@@ -2,6 +2,7 @@ mod bevy_animation;
 pub use bevy_animation::*;
 use bevy::prelude::*;
 use bevy::state::state::FreelyMutableState;
+use bevy_egui::EguiPrimaryContextPass;
 
 mod game_menus;
 mod bevy_physics;
@@ -34,7 +35,7 @@ impl<T> Plugin for GameStatePlugin<T>
   fn build(&self, app: &mut App) {
     app.init_state::<T>();
     //START_HIGHLIGHT
-    app.add_plugins(bevy_egui::EguiPlugin{ enable_multipass_for_primary_context: false });
+    app.add_plugins(bevy_egui::EguiPlugin::default());
     //END_HIGHLIGHT
     let start = MenuResource {
       menu_state: self.menu_state,
@@ -53,7 +54,7 @@ impl<T> Plugin for GameStatePlugin<T>
     app.add_systems(OnExit(self.game_end_state), cleanup::<game_menus::MenuElement>);
 
     app.add_systems(OnEnter(T::default()), crate::bevy_assets::setup);
-    app.add_systems(Update, crate::bevy_assets::run::<T>.run_if(in_state(T::default())));
+    app.add_systems(EguiPrimaryContextPass, crate::bevy_assets::run::<T>.run_if(in_state(T::default())));
     app.add_systems(OnExit(T::default()), crate::bevy_assets::exit);
   }
 }

--- a/FlappyPhysics/my_library/src/bevy_assets/loading_menu.rs
+++ b/FlappyPhysics/my_library/src/bevy_assets/loading_menu.rs
@@ -40,7 +40,7 @@ pub(crate) fn run<T>(
     mut texture_atlases: ResMut<Assets<TextureAtlasLayout>>,
     loaded_assets: Res<LoadedAssets>,
     // END_HIGHLIGHT
-) where T: States+FromWorld+FreelyMutableState,
+) -> Result where T: States+FromWorld+FreelyMutableState,
 {
     to_load.0.retain(|handle| {
         match asset_server.get_load_state(handle.id()) {
@@ -57,11 +57,12 @@ pub(crate) fn run<T>(
     }
     //END: finished_loading
     Window::new("Loading, Please Wait").show(
-        egui_context.ctx_mut(), |ui| {
+        egui_context.ctx_mut()?, |ui| {
             ui.label(
                 format!("{} assets remaining", to_load.0.len())
             )
         });
+    Ok(())
 }
 
 //START: load_atlases

--- a/FlappyPhysics/my_library/src/bevy_framework/mod.rs
+++ b/FlappyPhysics/my_library/src/bevy_framework/mod.rs
@@ -2,6 +2,7 @@ mod bevy_animation;
 pub use bevy_animation::*;
 use bevy::prelude::*;
 use bevy::state::state::FreelyMutableState;
+use bevy_egui::EguiPrimaryContextPass;
 
 mod game_menus;
 mod bevy_physics;
@@ -32,7 +33,7 @@ impl<T> Plugin for GameStatePlugin<T>
   fn build(&self, app: &mut App) {
     app.init_state::<T>();
     //START_HIGHLIGHT
-    app.add_plugins(bevy_egui::EguiPlugin{ enable_multipass_for_primary_context: false });
+    app.add_plugins(bevy_egui::EguiPlugin::default());
     //END_HIGHLIGHT
     let start = MenuResource {
       menu_state: self.menu_state,
@@ -51,7 +52,7 @@ impl<T> Plugin for GameStatePlugin<T>
     app.add_systems(OnExit(self.game_end_state), cleanup::<game_menus::MenuElement>);
 
     app.add_systems(OnEnter(T::default()), crate::bevy_assets::setup);
-    app.add_systems(Update, crate::bevy_assets::run::<T>.run_if(in_state(T::default())));
+    app.add_systems(EguiPrimaryContextPass, crate::bevy_assets::run::<T>.run_if(in_state(T::default())));
     app.add_systems(OnExit(T::default()), crate::bevy_assets::exit);
   }
 }

--- a/FlappyWrap/my_library/src/bevy_assets/loading_menu.rs
+++ b/FlappyWrap/my_library/src/bevy_assets/loading_menu.rs
@@ -40,7 +40,7 @@ pub(crate) fn run<T>(
     mut texture_atlases: ResMut<Assets<TextureAtlasLayout>>,
     loaded_assets: Res<LoadedAssets>,
     // END_HIGHLIGHT
-) where T: States+FromWorld+FreelyMutableState,
+) -> Result where T: States+FromWorld+FreelyMutableState,
 {
     to_load.0.retain(|handle| {
         match asset_server.get_load_state(handle.id()) {
@@ -57,11 +57,12 @@ pub(crate) fn run<T>(
     }
     //END: finished_loading
     Window::new("Loading, Please Wait").show(
-        egui_context.ctx_mut(), |ui| {
+        egui_context.ctx_mut()?, |ui| {
             ui.label(
                 format!("{} assets remaining", to_load.0.len())
             )
         });
+    Ok(())
 }
 
 //START: load_atlases

--- a/FlappyWrap/my_library/src/bevy_framework/mod.rs
+++ b/FlappyWrap/my_library/src/bevy_framework/mod.rs
@@ -2,6 +2,7 @@ mod bevy_animation;
 pub use bevy_animation::*;
 use bevy::prelude::*;
 use bevy::state::state::FreelyMutableState;
+use bevy_egui::EguiPrimaryContextPass;
 
 mod game_menus;
 mod bevy_physics;
@@ -34,7 +35,7 @@ impl<T> Plugin for GameStatePlugin<T>
   fn build(&self, app: &mut App) {
     app.init_state::<T>();
     //START_HIGHLIGHT
-    app.add_plugins(bevy_egui::EguiPlugin{ enable_multipass_for_primary_context: false });
+    app.add_plugins(bevy_egui::EguiPlugin::default());
     //END_HIGHLIGHT
     let start = MenuResource {
       menu_state: self.menu_state,
@@ -53,7 +54,7 @@ impl<T> Plugin for GameStatePlugin<T>
     app.add_systems(OnExit(self.game_end_state), cleanup::<game_menus::MenuElement>);
 
     app.add_systems(OnEnter(T::default()), crate::bevy_assets::setup);
-    app.add_systems(Update, crate::bevy_assets::run::<T>.run_if(in_state(T::default())));
+    app.add_systems(EguiPrimaryContextPass, crate::bevy_assets::run::<T>.run_if(in_state(T::default())));
     app.add_systems(OnExit(T::default()), crate::bevy_assets::exit);
   }
 }

--- a/MarsBaseOneOptimize/mars_base_one_collision/src/main.rs
+++ b/MarsBaseOneOptimize/mars_base_one_collision/src/main.rs
@@ -27,14 +27,14 @@ fn main() -> anyhow::Result<()> {
   let mut app = App::new();
   add_phase!(app, GamePhase, GamePhase::WorldBuilding,
     start => [ spawn_builder ],
-    run => [ show_builder ],
+    run => [ ],
     exit => [ ]
   );
   add_phase!(app, GamePhase, GamePhase::Playing,
     start => [ setup ],
     run => [ movement, end_game, physics_clock, sum_impulses, apply_gravity, apply_velocity,
       terminal_velocity, check_collisions::<Player, Ground>, bounce, camera_follow,
-      show_performance, spawn_particle_system, particle_age_system ],
+      spawn_particle_system, particle_age_system ],
     exit => [ cleanup::<GameElement> ]
   );
 
@@ -76,6 +76,8 @@ fn main() -> anyhow::Result<()> {
       .add_event::<SpawnParticle>()
       //END_HIGHLIGHT
       //END: SpawnParticleEvent
+      .add_systems(EguiPrimaryContextPass, show_builder.run_if(in_state(GamePhase::WorldBuilding)))
+      .add_systems(EguiPrimaryContextPass, show_performance.run_if(in_state(GamePhase::Playing)))
       .run();
 
   Ok(())
@@ -85,6 +87,7 @@ static WORLD_READY: AtomicBool = AtomicBool::new(false);
 use std::sync::Mutex;
 use bevy::asset::RenderAssetUsages;
 use bevy::render::camera::ScalingMode;
+use my_library::egui::EguiPrimaryContextPass;
 
 static NEW_WORLD: Mutex<Option<World>> = Mutex::new(None);
 
@@ -114,9 +117,9 @@ fn spawn_builder() {
 fn show_builder(
   mut state: ResMut<NextState<GamePhase>>,
   mut egui_context: egui::EguiContexts,
-) {
+) -> Result {
   egui::egui::Window::new("Performance").show(
-    egui_context.ctx_mut(),
+    egui_context.ctx_mut()?,
     |ui| {
       ui.label("Building World");
     });
@@ -124,6 +127,7 @@ fn show_builder(
   if WORLD_READY.load(std::sync::atomic::Ordering::Relaxed) {
     state.set(GamePhase::Playing);
   }
+  Ok(())
 }
 //END: WorldBuildingDone
 
@@ -562,13 +566,13 @@ impl World {
 fn show_performance(
   diagnostics: Res<DiagnosticsStore>,
   mut egui_context: egui::EguiContexts,
-) {
+) -> Result {
   let fps = diagnostics
       .get(&FrameTimeDiagnosticsPlugin::FPS)
       .and_then(|fps| fps.average())
       .unwrap_or(0.0);
   egui::egui::Window::new("Performance").show(
-    egui_context.ctx_mut(),
+    egui_context.ctx_mut()?,
     |ui| {
       let fps_text = format!("FPS: {fps:.1}");
       let color = match fps as u32 {
@@ -578,6 +582,7 @@ fn show_performance(
       };
       ui.colored_label(color, &fps_text);
     });
+  Ok(())
 }
 //END: ShowFPS
 

--- a/MarsBaseOneSkeleton/my_library/src/bevy_assets/loading_menu.rs
+++ b/MarsBaseOneSkeleton/my_library/src/bevy_assets/loading_menu.rs
@@ -40,7 +40,7 @@ pub(crate) fn run<T>(
     mut texture_atlases: ResMut<Assets<TextureAtlasLayout>>,
     loaded_assets: Res<LoadedAssets>,
     // END_HIGHLIGHT
-) where T: States+FromWorld+FreelyMutableState,
+) -> Result where T: States+FromWorld+FreelyMutableState,
 {
     to_load.0.retain(|handle| {
         match asset_server.get_load_state(handle.id()) {
@@ -57,11 +57,12 @@ pub(crate) fn run<T>(
     }
     //END: finished_loading
     Window::new("Loading, Please Wait").show(
-        egui_context.ctx_mut(), |ui| {
+        egui_context.ctx_mut()?, |ui| {
             ui.label(
                 format!("{} assets remaining", to_load.0.len())
             )
         });
+    Ok(())
 }
 
 //START: load_atlases

--- a/MarsBaseOneSkeleton/my_library/src/bevy_framework/mod.rs
+++ b/MarsBaseOneSkeleton/my_library/src/bevy_framework/mod.rs
@@ -2,6 +2,7 @@ mod bevy_animation;
 pub use bevy_animation::*;
 use bevy::prelude::*;
 use bevy::state::state::FreelyMutableState;
+use bevy_egui::EguiPrimaryContextPass;
 
 mod game_menus;
 mod bevy_physics;
@@ -34,7 +35,7 @@ impl<T> Plugin for GameStatePlugin<T>
   fn build(&self, app: &mut App) {
     app.init_state::<T>();
     //START_HIGHLIGHT
-    app.add_plugins(bevy_egui::EguiPlugin{ enable_multipass_for_primary_context: false });
+    app.add_plugins(bevy_egui::EguiPlugin::default());
     //END_HIGHLIGHT
     let start = MenuResource {
       menu_state: self.menu_state,
@@ -53,7 +54,7 @@ impl<T> Plugin for GameStatePlugin<T>
     app.add_systems(OnExit(self.game_end_state), cleanup::<game_menus::MenuElement>);
 
     app.add_systems(OnEnter(T::default()), crate::bevy_assets::setup);
-    app.add_systems(Update, crate::bevy_assets::run::<T>.run_if(in_state(T::default())));
+    app.add_systems(EguiPrimaryContextPass, crate::bevy_assets::run::<T>.run_if(in_state(T::default())));
     app.add_systems(OnExit(T::default()), crate::bevy_assets::exit);
   }
 }

--- a/MarsBaseOneWorldBuilder/mars_base_one_threaded/src/main.rs
+++ b/MarsBaseOneWorldBuilder/mars_base_one_threaded/src/main.rs
@@ -27,7 +27,7 @@ fn main() -> anyhow::Result<()> {
   //START: WorldBuildingPhase
   add_phase!(app, GamePhase, GamePhase::WorldBuilding,
     start => [ spawn_builder ],
-    run => [ show_builder ],
+    run => [ ],
     exit => [ ]
   );
   //END: WorldBuildingPhase
@@ -61,6 +61,7 @@ fn main() -> anyhow::Result<()> {
       )
       .insert_resource(Animations::new())
       .add_event::<OnCollision<Player, Ground>>()
+      .add_systems(EguiPrimaryContextPass, show_builder.run_if(in_state(GamePhase::WorldBuilding)))
       .run();
 
   Ok(())
@@ -72,6 +73,7 @@ static WORLD_READY: AtomicBool = AtomicBool::new(false);
 //START: WorldMutex
 use std::sync::Mutex;
 use bevy::render::camera::ScalingMode;
+use my_library::egui::EguiPrimaryContextPass;
 
 static NEW_WORLD: Mutex<Option<World>> = Mutex::new(None);
 //END: WorldMutex
@@ -106,9 +108,9 @@ fn spawn_builder() {
 fn show_builder(
   mut state: ResMut<NextState<GamePhase>>,
   mut egui_context: egui::EguiContexts,
-) {
+) -> Result {
   egui::egui::Window::new("Performance").show(
-    egui_context.ctx_mut(),
+    egui_context.ctx_mut()?,
     |ui| {
       ui.label("Building World");
     });
@@ -116,6 +118,7 @@ fn show_builder(
   if WORLD_READY.load(std::sync::atomic::Ordering::Relaxed) {
     state.set(GamePhase::Playing);
   }
+  Ok(())
 }
 //END: WorldBuildingDone
 


### PR DESCRIPTION
The PR adapts the code to the breaking changes in the latest bevy_egui release: https://github.com/vladbat00/bevy_egui/releases/tag/v0.35.0

I haven't got a chance to test the changes but they compile at least. Also, the callout tags and formatting might need fixing in some places (I was hesitant to run `cargo fmt`). In some places, I had to move systems outside of the `add_phase` macro as it doesn't support customising schedules.